### PR TITLE
Default behavior in distutils does not include MANIFEST.in itself, which

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,8 @@
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    # This package will not be re-distributable
+    from distutils.core import setup
 
 with open("README.rst") as f:
     readme = f.read()


### PR DESCRIPTION
causes re-distribution to break (README.rst dependency within setup.py)

Here's the issue with current master, discovered when I attempted to re-package what is available on public PyPI:

```
bz2file $ mkdir 1 2
bz2file $ python setup.py sdist
running sdist
running check
...
Creating tar archive
removing 'bz2file-0.98' (and everything under it)
```

```

bz2file $ tar  xzf  dist/bz2file-0.98.tar.gz  -C 1

bz2file $ (cd 1/bz2file-0.98; python setup.py sdist)
running sdist
running check
warning: sdist: manifest template 'MANIFEST.in' does not exist (using default file list)

warning: sdist: standard file not found: should have one of README, README.txt

writing manifest file 'MANIFEST'
...
Creating tar archive
removing 'bz2file-0.98' (and everything under it)
```

```
bz2file $ tar  xzf  1/bz2file-0.98/dist/bz2file-0.98.tar.gz  -C 2

bz2file $ (cd 2/bz2file-0.98; python setup.py sdist)
Traceback (most recent call last):
  File "setup.py", line 3, in <module>
    with open("README.rst") as f:
IOError: [Errno 2] No such file or directory: 'README.rst'
```
